### PR TITLE
Update setValueWithCallback to always return the same function reference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
 
 const useStateWithCallback = (initialState, callback) => {
   const [state, setState] = useState(initialState);
@@ -29,14 +29,14 @@ const useStateWithCallbackLazy = initialValue => {
     }
   }, [value]);
 
-  const setValueWithCallback = (newValue, callback) => {
+  const setValueWithCallback = useCallback((newValue, callback) => {
     callbackRef.current = callback;
 
     return setValue(newValue);
   };
 
   return [value, setValueWithCallback];
-};
+}, [setValue]);
 
 export { useStateWithCallbackInstant, useStateWithCallbackLazy };
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,10 @@ const useStateWithCallbackLazy = initialValue => {
     callbackRef.current = callback;
 
     return setValue(newValue);
-  };
+  }, [setValue]));
 
   return [value, setValueWithCallback];
-}, [setValue]);
+};
 
 export { useStateWithCallbackInstant, useStateWithCallbackLazy };
 


### PR DESCRIPTION
To follow React hooks more closely make sure to always return the same reference for `setValueWithCallback` .

https://reactjs.org/docs/hooks-reference.html#usestate
![image](https://user-images.githubusercontent.com/1838071/101334930-2f463900-3881-11eb-847e-2b34ac558dc1.png)
