### PR TITLE
Async Callback provided within a callback doesn't get executed : fixe…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,16 +22,16 @@ const useStateWithCallbackLazy = initialValue => {
   const [value, setValue] = useState(initialValue);
 
   useEffect(() => {
-    if (callbackRef.current) {
+    if (
+      callbackRef.current &&
+      typeof callbackRef.current === 'function'
+    ) {
       callbackRef.current(value);
-
-      callbackRef.current = null;
     }
   }, [value]);
 
   const setValueWithCallback = (newValue, callback) => {
     callbackRef.current = callback;
-
     return setValue(newValue);
   };
 


### PR DESCRIPTION
- Added Type condition while executing the callback function in the useEffect. 
- Removed null assignment to the callbackRef.current as it gets undefined when no function is found in the parameter of setValueWithCallback